### PR TITLE
Use SelectedListItem as argument in listItemBuilder instead of index

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ This property takes List<SelectedListItem> as a parameter and it is useful to di
 
 ### Optional parameters
 
-##### listBuilder:
-This property takes int value as a parameter. This is use to set the initial segment from [segmentNames].
+##### listItemBuilder:
+This property takes a builder function with `SelectedItem` as argument. It is used to customize the rendering of the list items.
 
 ##### enableMultipleSelection:
 This property takes Color value as a parameter. You can change the background color of animated segment. default value is `Color(0xff8AADFB)`

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This property takes List<SelectedListItem> as a parameter and it is useful to di
 ### Optional parameters
 
 ##### listItemBuilder:
-This property takes a builder function with `SelectedItem` as argument. It is used to customize the rendering of the list items.
+This property takes a builder function with `SelectedListItem` as argument. It is used to customize the rendering of the list items.
 
 ##### enableMultipleSelection:
 This property takes Color value as a parameter. You can change the background color of animated segment. default value is `Color(0xff8AADFB)`

--- a/lib/src/drop_down.dart
+++ b/lib/src/drop_down.dart
@@ -5,7 +5,7 @@ import 'app_text_field.dart';
 
 typedef SelectedItemsCallBack = Function(List<SelectedListItem> selectedItems);
 
-typedef ListItemBuilder = Widget Function(int index);
+typedef ListItemBuilder = Widget Function(SelectedListItem item);
 
 typedef BottomSheetListener = bool Function(DraggableScrollableNotification draggableScrollableNotification);
 
@@ -16,7 +16,7 @@ class DropDown {
   /// This will give the call back to the selected items from list.
   final SelectedItemsCallBack? selectedItems;
 
-  /// [listItemBuilder] will gives [index] as a function parameter and you can return your own widget based on [index].
+  /// [listItemBuilder] will give [SelectedItem] as a function parameter and you can return your own widget based on that item.
   final ListItemBuilder? listItemBuilder;
 
   /// This will give selection choice for single or multiple for list.
@@ -187,7 +187,7 @@ class _MainBodyState extends State<MainBody> {
                         child: Padding(
                           padding: const EdgeInsets.fromLTRB(20, 10, 20, 0),
                           child: ListTile(
-                            title: widget.dropDown.listItemBuilder?.call(index) ??
+                            title: widget.dropDown.listItemBuilder?.call(mainList[index]) ??
                                 Text(
                                   mainList[index].name,
                                 ),

--- a/lib/src/drop_down.dart
+++ b/lib/src/drop_down.dart
@@ -16,7 +16,7 @@ class DropDown {
   /// This will give the call back to the selected items from list.
   final SelectedItemsCallBack? selectedItems;
 
-  /// [listItemBuilder] will give [SelectedItem] as a function parameter and you can return your own widget based on that item.
+  /// [listItemBuilder] will give [SelectedListItem] as a function parameter and you can return your own widget based on that item.
   final ListItemBuilder? listItemBuilder;
 
   /// This will give selection choice for single or multiple for list.


### PR DESCRIPTION
Closes #16 

This PR replaces the parameter in `ListItemBuilder` function with `SelectedListItem`, instead of integer index.

The reason is that if the search is used, it produces a subset list that has no longer valid indexes for matching it with the original list. So it's impossible to customize the rendering of the items for searched items.

So as we replace an arbitrary index with `SelectedListItem`, we now have `SelectedListItem.value` which can be used to match the item in the original list, and thus use this data to render a custom widget.

The change can be considered breaking, but it is absolutely crucial, so to make it work with the search.
