### PR TITLE
Add useRootNavigator Parameter to DropDown widget

### DIFF
--- a/lib/src/drop_down.dart
+++ b/lib/src/drop_down.dart
@@ -51,6 +51,10 @@ class DropDown {
   /// [bottomSheetListener] that listens for BottomSheet bubbling up the tree.
   final BottomSheetListener? bottomSheetListener;
 
+  // Specifies whether a modal bottom sheet should be displayed using the root navigator.
+  /// by default it is [False].
+  final bool useRootNavigator;
+
   DropDown({
     Key? key,
     required this.data,
@@ -65,6 +69,7 @@ class DropDown {
     this.isSearchVisible = true,
     this.dropDownBackgroundColor = Colors.transparent,
     this.bottomSheetListener,
+    this.useRootNavigator = false,
   });
 }
 
@@ -76,6 +81,7 @@ class DropDownState {
   /// This gives the bottom sheet widget.
   void showModal(context) {
     showModalBottomSheet(
+      useRootNavigator: dropDown.useRootNavigator,
       isScrollControlled: true,
       enableDrag: dropDown.isDismissible,
       isDismissible: dropDown.isDismissible,

--- a/lib/src/drop_down.dart
+++ b/lib/src/drop_down.dart
@@ -51,7 +51,7 @@ class DropDown {
   /// [bottomSheetListener] that listens for BottomSheet bubbling up the tree.
   final BottomSheetListener? bottomSheetListener;
 
-  // Specifies whether a modal bottom sheet should be displayed using the root navigator.
+  /// Specifies whether a modal bottom sheet should be displayed using the root navigator.
   /// by default it is [False].
   final bool useRootNavigator;
 


### PR DESCRIPTION
This pull request adds the `useRootNavigator` parameter to the DropDown widget. This is particularly useful in applications with nested navigators, where the desired behaviour is to have the modal bottom sheet appear on top of all routes, regardless of the navigator stack it was called from.
